### PR TITLE
Sync PodSpec fields with package.json

### DIFF
--- a/ios/RNImageModifier.podspec
+++ b/ios/RNImageModifier.podspec
@@ -1,24 +1,22 @@
+require 'json'
+
+pakcage = JSON.parse(File.read(File.join('..', 'package.json')))
 
 Pod::Spec.new do |s|
   s.name         = "RNImageModifier"
-  s.version      = "1.0.0"
+  s.version      = package['version']
   s.summary      = "RNImageModifier"
-  s.description  = <<-DESC
-                  RNImageModifier
-                   DESC
-  s.homepage     = ""
-  s.license      = "MIT"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.author             = { "author" => "kellin.me@navercorp.com" }
+  s.description  = package['description']
+  s.homepage     = package['homepage']
+  s.license      = package['license']
+  s.author       = package['author']
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/naver/react-native-image-modifier", :tag => "master" }
+  s.source       = { :git => "https://github.com/naver/react-native-image-modifier.git", :tag => "master" }
   s.source_files  = "RNImageModifier/**/*.{h,m}"
   s.requires_arc = true
 
 
   s.dependency "React"
-  #s.dependency "others"
-
 end
 
   


### PR DESCRIPTION
### Related Issue
.

### Changes and Reasons
* unnecessarily duplicated values here, so respect `package.json`'s field instead.
* as of RN@0.6x, when `pod install`, an error occurs. 
```sh
[!] The `RNImageModifier` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | github_sources: Github repositories should end in `.git`.
    - WARN  | description: The description is equal to the summary.
```

### PR Point
<!-- Please enter what the reviewers would like to see. -->

### Note
with this change, version number goes down to 0.1.3 ( 1.0.0 previously )
so, please update the version number on `package.json` before the next release.
